### PR TITLE
Add support for private and drafts datasets

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-max-line-length = 300
+max-line-length = 120
 max-complexity = 8
 exclude = .venv*,venv*,.git,__pycache__,.tox,.eggs,*.egg

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 *.egg-info
 *.pyc
 /docs/_build/*
+metastore
+.vscode

--- a/migrate_metadata/ckan_api.py
+++ b/migrate_metadata/ckan_api.py
@@ -30,6 +30,35 @@ class CkanAPIClient:
         data = response.json()
         return self.get_result(data)
 
+    def package_search(self, params=None):
+        url = self.create_url('/api/3/action/package_search', params=params)
+        response = requests.get(
+            url, headers={'Authorization': self.ckan_api_key}
+            )
+        data = response.json()
+        return self.get_result(data)
+
+    def get_datasets_list_from_search(self, params):
+        """Iterates through the package_search API and returns a python list
+        of all datasets including draft and private ones.
+
+        In order to extract a clean complete list of datasets objects we need to
+        iterate over the hard limit of 1000 per query and on each extract the
+        dataset list from the result json.
+        """
+        datasets = []
+        start = 0
+        while True:
+            params['start'] = start
+            result = self.package_search(params=params)
+            rows = result['results']
+            if rows == []:
+                break
+            datasets.extend(rows)
+            start += len(rows)
+
+        return datasets
+
     def create_url(self, path, params=None):
         url = urljoin(self.ckan_api_url, path)
         if params:

--- a/migrate_metadata/ckan_api.py
+++ b/migrate_metadata/ckan_api.py
@@ -40,7 +40,7 @@ class CkanAPIClient:
 
     def get_datasets_list_from_search(self, params):
         """Iterates through the package_search API and returns a python list
-        of all datasets including draft and private ones.
+        of all datasets.
 
         In order to extract a clean complete list of datasets objects we need to
         iterate over the hard limit of 1000 per query and on each extract the

--- a/migrate_metadata/ckan_api.py
+++ b/migrate_metadata/ckan_api.py
@@ -60,7 +60,7 @@ class CkanAPIClient:
         """Get the result of the function called from the response object.
 
         CKAN API aims to always return 200 OK as the status code of its HTTP
-        response and the actual result f the function called in the result
+        response and the actual result of the function called in the result
         element of the response.
 
         https://docs.ckan.org/en/2.8/api/index.html#making-an-api-request

--- a/migrate_metadata/ckan_api.py
+++ b/migrate_metadata/ckan_api.py
@@ -1,5 +1,4 @@
 import requests
-from requests.exceptions import RequestException
 from six.moves.urllib.parse import urlencode, urljoin
 
 

--- a/tests/test_ckan_api.py
+++ b/tests/test_ckan_api.py
@@ -26,19 +26,30 @@ def test_create_url_with_params(ckan_client):
 
 
 def test_get_result_returns_result_element_of_response(ckan_client):
-    data = json.loads('{"help": "http://ckan:5000/api/3/action/help_show?name=package_list", "success": true, "result": ["dataset-with-no-releases", "github-dataset", "new-dataset-on-github", "testing-personal-storage-account", "testing-removed-resources"]}')
+    data = json.loads(
+        '{"help": "http://ckan:5000/api/3/action/help_show?name=package_list", '
+        '"success": true, "result": ["dataset-with-no-releases", "github-dataset", '
+        '"new-dataset-on-github", "testing-personal-storage-account", "testing-removed-resources"]}'
+        )
     assert ckan_client.get_result(data) == data['result']
 
 
 def test_get_result_raises_error_if_api_call_returns_success_false(ckan_client):
-    data = json.loads('{"help": "http://ckan:5000/api/3/action/help_show?name=package_show", "success": false, "error": {"message": "Not found", "__type": "Not Found Error"}}')
+    data = json.loads(
+        '{"help": "http://ckan:5000/api/3/action/help_show?name=package_show", '
+        '"success": false, "error": {"message": "Not found", "__type": "Not Found Error"}}'
+        )
     with pytest.raises(CkanAPIError) as execinfo:
         ckan_client.get_result(data)
     assert str(execinfo.value) == "Not found"
 
 
 def test_package_list(requests_mock, ckan_client):
-    mock_content = '{"help": "http://ckan:5000/api/3/action/help_show?name=package_list", "success": true, "result": ["dataset-with-no-releases", "github-dataset", "new-dataset-on-github", "testing-personal-storage-account", "testing-removed-resources"]}'
+    mock_content = (
+        '{"help": "http://ckan:5000/api/3/action/help_show?name=package_list", '
+        '"success": true, "result": ["dataset-with-no-releases", "github-dataset", '
+        '"new-dataset-on-github", "testing-personal-storage-account", "testing-removed-resources"]}'
+        )
     mocked_url = ckan_client.create_url('/api/3/action/package_list')
     requests_mock.get(mocked_url, content=mock_content)
     assert json.loads(mock_content)['result'] == ckan_client.package_list()
@@ -46,16 +57,23 @@ def test_package_list(requests_mock, ckan_client):
 
 def test_package_show(requests_mock, ckan_client):
     pkg_name = "github-dataset"
-    mock_content = '{"help": "http://ckan:5000/api/3/action/help_show?name=package_show", "success": true, "result": {"name": "github-dataset"} }'
+    mock_content = (
+        '{"help": "http://ckan:5000/api/3/action/help_show?name=package_show", '
+        '"success": true, "result": {"name": "github-dataset"} }'
+        )
+    result = json.loads(mock_content)['result']
     mocked_url = ckan_client.create_url('/api/3/action/package_show?id={}'.format(pkg_name))
     requests_mock.get(mocked_url, content=mock_content)
-    result = json.loads(mock_content)['result']
 
     assert result == ckan_client.package_show(pkg_name)
 
 
 def test_package_search(requests_mock, ckan_client):
-    mock_content = '{"help": "http://ckan:5000/api/3/action/help_show?name=package_search", "success": true, "result": {"count": 5, "sort": "score desc, metadata_modified desc", "facets": {}, "results": [{"name": "github-dataset"}], "search_facets": {}}}'
+    mock_content = (
+        '{"help": "http://ckan:5000/api/3/action/help_show?name=package_search", '
+        '"success": true, "result": {"count": 5, "sort": "score desc, metadata_modified desc", '
+        '"facets": {}, "results": [{"name": "github-dataset"}], "search_facets": {}}}'
+        )
     mocked_url = ckan_client.create_url('/api/3/action/package_search')
     requests_mock.get(mocked_url, content=mock_content)
     expected_result = json.loads(mock_content)['result']
@@ -70,7 +88,11 @@ def test_get_datasets_list_from_search(requests_mock, ckan_client):
 
     # Mocking first API call
     mocked_params['start'] = 0
-    mocked_search_result_1 = '{"help": "http://ckan:5000/api/3/action/help_show?name=package_search", "success": true, "result": {"count": 3, "sort": "score desc, metadata_modified desc", "facets": {}, "results": [{"name": "test_pkg_0"}, {"name": "test_pkg_1"}], "search_facets": {}}}'
+    mocked_search_result_1 = (
+        '{"help": "http://ckan:5000/api/3/action/help_show?name=package_search", '
+        '"success": true, "result": {"count": 3, "sort": "score desc, metadata_modified desc", '
+        '"facets": {}, "results": [{"name": "test_pkg_0"}, {"name": "test_pkg_1"}], "search_facets": {}}}'
+        )
     mocked_url = ckan_client.create_url(
         '/api/3/action/package_search',
         params=mocked_params
@@ -79,7 +101,11 @@ def test_get_datasets_list_from_search(requests_mock, ckan_client):
 
     # Mocking second API call
     mocked_params['start'] = 2
-    mocked_search_result_2 = '{"help": "http://ckan:5000/api/3/action/help_show?name=package_search", "success": true, "result": {"count": 3, "sort": "score desc, metadata_modified desc", "facets": {}, "results": [{"name": "test_pkg_2"}], "search_facets": {}}}'
+    mocked_search_result_2 = (
+        '{"help": "http://ckan:5000/api/3/action/help_show?name=package_search", '
+        '"success": true, "result": {"count": 3, "sort": "score desc, metadata_modified desc", '
+        '"facets": {}, "results": [{"name": "test_pkg_2"}], "search_facets": {}}}'
+        )
     mocked_url = ckan_client.create_url(
         '/api/3/action/package_search',
         params=mocked_params
@@ -88,7 +114,11 @@ def test_get_datasets_list_from_search(requests_mock, ckan_client):
 
     # Mocking third API call
     mocked_params['start'] = 3
-    mocked_search_result_3 = '{"help": "http://ckan:5000/api/3/action/help_show?name=package_search", "success": true, "result": {"count": 3, "sort": "score desc, metadata_modified desc", "facets": {}, "results": [], "search_facets": {}}}'
+    mocked_search_result_3 = (
+        '{"help": "http://ckan:5000/api/3/action/help_show?name=package_search", '
+        '"success": true, "result": {"count": 3, "sort": "score desc, metadata_modified desc", '
+        '"facets": {}, "results": [], "search_facets": {}}}'
+        )
     mocked_url = ckan_client.create_url(
         '/api/3/action/package_search',
         params=mocked_params

--- a/tests/test_migrator.py
+++ b/tests/test_migrator.py
@@ -5,10 +5,11 @@ from migrate_metadata import migrator
 def test_migrate_datasets_migrates_only_of_type_dataset():
     datasets = [
         {"name": "test_pkg_0", "author": "test_user", "type": "dataset"},
-        {"name": "test_pkg_1", "author": "test_user", "type": "showcase"}
+        {"name": "test_pkg_1", "author": "test_user", "type": "showcase"},
+        {"name": "test_pkg_2", "author": "test_user", "type": "dataset"},
         ]
 
     metastore_client = metastore.create_metastore("filesystem", dict(uri="mem://"))
     number_of_datasets = migrator.migrate_datasets((datasets), metastore_client)
 
-    assert number_of_datasets == 1
+    assert number_of_datasets == 2


### PR DESCRIPTION
This PR implements #11 to add support to migrate both `private` and `drafts` dataset.
